### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+
 ## [Unreleased] - YYYY-MM-DD
+#### Added
+#### Changed
+#### Deprecated
+#### Removed
+#### Fixed
+#### Security
+
+
+
+
+## [1.4.0] - 2015-12-29
 #### Added
 - API: `/api/apps` listing of all the apps (subset of the root status data-set.  
   Makes for a logically consistent API).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Changed
 - Manifest: Now optionally supporting an array of routes per app.
 - Sorting apps by route upon adding them to the main API.
-#### Deprecated
 #### Removed
 - Removed auto-restart when `manifest.yml` file changes.
     - Was causing strange errors.
     - Now when the manifest changes force a restart using the REST api: `/api/restart`
-#### Fixed
-#### Security
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - API: `/api/apps` listing of all the apps (subset of the root status data-set.  
   Makes for a logically consistent API).
 #### Changed
+- Manifest: Now optionally supporting an array of routes per app.
 #### Deprecated
 #### Removed
 - Removed auto-restart when `manifest.yml` file changes.
@@ -15,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Now when the manifest changes force a restart using the REST api: `/api/restart`
 #### Fixed
 #### Security
+
+
 
 
 ## [1.3.0] - 2015-12-22
@@ -33,11 +36,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updates on Github callback when `manifest.yml` changes.
 
 
+
+
 ## [1.2.0] - 2015-12-16
 #### Added
 - Added secret `tokens` for locking down the API (specified within `manifest.yml`).
 - API Action: Update
 - API Action: Restart
+
+
 
 
 ## [1.1.0] - 2015-12-14
@@ -48,6 +55,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed the use of the `file-system-cache` as a means of communicating when other instances are downloading an app.  Now using RabbitMQ and pub/sub for inter-container communication.
 
 
+
+
 ## [1.0.6] - 2015-11-30
 #### Added
 - Reading `targetFolder` from manifest.
@@ -56,12 +65,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `TARGET_FOLDER` environment variable.
 
 
+
+
 ## [1.0.1] - 2015-11-30
 #### Added
 - Version of the `app-sync` module on API status.
 #### Changed
 - API as an object on manifest (eg. `api/route`).
   This allows for more details (like `tokens`) to be associated with the API within the manifest.
+
+
 
 
 ## [1.0.0] - 2015-11-29
@@ -73,6 +86,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Changed
 - Only running NPM install when absolutely required (faster).
+
+
 
 
 ## [0.0.2] - 2015-11-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Makes for a logically consistent API).
 #### Changed
 - Manifest: Now optionally supporting an array of routes per app.
+- Sorting apps by route upon adding them to the main API.
 #### Deprecated
 #### Removed
 - Removed auto-restart when `manifest.yml` file changes.

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.45",
+  "version": "2.1.46",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.40",
+  "version": "2.1.41",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.49",
+  "version": "2.1.50",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.43",
+  "version": "2.1.44",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.48",
+  "version": "2.1.49",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.44",
+  "version": "2.1.45",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.47",
+  "version": "2.1.48",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.50",
+  "version": "2.1.51",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.42",
+  "version": "2.1.43",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-1/package.json
+++ b/example/app-1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-1",
-  "version": "2.1.41",
+  "version": "2.1.42",
   "main": "./index.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/app-2/package.json
+++ b/example/app-2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-2",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "./main.js",
   "dependencies": {
     "express": "^4.13.3",

--- a/example/manifest.yml
+++ b/example/manifest.yml
@@ -15,5 +15,5 @@ apps:
     repo: "philcockfield/app-sync/example/app-1"
     route:
       - "*/1"
-      - "*/bar"
+      - "*/one"
     branch: "devel"

--- a/example/manifest.yml
+++ b/example/manifest.yml
@@ -10,7 +10,7 @@ apps:
   foo:
     repo: "philcockfield/app-sync/example/app-2"
     route: "*"
-    branch: "devel____"
+    branch: "devel"
   bar:
     repo: "philcockfield/app-sync/example/app-1"
     route: "*/1"

--- a/example/manifest.yml
+++ b/example/manifest.yml
@@ -10,7 +10,7 @@ apps:
   foo:
     repo: "philcockfield/app-sync/example/app-2"
     route: "*"
-    branch: "devel"
+    branch: "devel____"
   bar:
     repo: "philcockfield/app-sync/example/app-1"
     route: "*/1"

--- a/example/manifest.yml
+++ b/example/manifest.yml
@@ -10,7 +10,7 @@ apps:
   foo:
     repo: "philcockfield/app-sync/example/app-2"
     route: "*"
-    branch: "devel"
+    branch: "devel_"
   bar:
     repo: "philcockfield/app-sync/example/app-1"
     route: "*/1"

--- a/example/manifest.yml
+++ b/example/manifest.yml
@@ -13,5 +13,7 @@ apps:
     branch: "devel"
   bar:
     repo: "philcockfield/app-sync/example/app-1"
-    route: "*/1"
+    route:
+      - "*/1"
+      - "*/bar"
     branch: "devel"

--- a/example/manifest.yml
+++ b/example/manifest.yml
@@ -10,7 +10,7 @@ apps:
   foo:
     repo: "philcockfield/app-sync/example/app-2"
     route: "*"
-    branch: "devel_"
+    branch: "devel"
   bar:
     repo: "philcockfield/app-sync/example/app-1"
     route: "*/1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-sync",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Continuous deployment from Github.",
   "main": "./index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "watch": "nodemon ./example --ignore .build",
     "test": "./node_modules/mocha/bin/mocha --recursive --compilers js:babel/register",
     "tdd": "./node_modules/mocha/bin/mocha --recursive --compilers js:babel/register --watch",
-    "prepublish": "gulp lint",
-    "dbuild": "sh ./sh/docker-build.sh",
-    "drun": "sh ./sh/test-docker-run.sh"
+    "prepublish": "gulp lint"
   },
   "dependencies": {
     "amqplib": "^0.4.0",

--- a/sh/docker-build.sh
+++ b/sh/docker-build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-# Build and tag image.
-docker build -t philcockfield/app-sync .
-docker tag -f philcockfield/app-sync philcockfield/app-sync:latest

--- a/sh/test-docker-run.sh
+++ b/sh/test-docker-run.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-    # --name app-sync \
-
-docker run -t -p 80:3000 \
-    -e GITHUB_TOKEN=$GITHUB_TOKEN \
-    philcockfield/app-sync npm run example

--- a/src/api-actions.js
+++ b/src/api-actions.js
@@ -71,7 +71,10 @@ export default (settings = {}) => {
         app.update()
           .then(result => {
               res.send({ app: app.id, updated: result.updated, version: result.version });
-              log.info(`API:...Updated app '${ app.id }'.`);
+              const msg = result.updated
+                ? `API: ...updated app '${ app.id }' to version ${ result.version }.`
+                : `API: ...did not update app '${ app.id }', latest version ${ result.version } already running.`
+              log.info(msg);
           })
           .catch(err => res.status(500).send({ message: err.message }));
       }

--- a/src/api-actions.js
+++ b/src/api-actions.js
@@ -10,16 +10,15 @@ const delay = (msecs, func) => global.setTimeout(func, msecs);
  * Manages actions that change the state of the service.
  *
  * @param {Object} settings:
- *                  - apps:     Collection of apps to start.
  *                  - mainApi:  The main API.
  *
  */
 export default (settings = {}) => {
-  const { apps, mainApi } = settings;
+  const { mainApi } = settings;
 
   const getApp = (req, res) => {
         const id = req.params.app;
-        const app = R.find(item => item.id === id, apps);
+        const app = R.find(item => item.id === id, mainApi.apps);
         if (app) {
           return app;
         } else {

--- a/src/api-actions.js
+++ b/src/api-actions.js
@@ -73,7 +73,7 @@ export default (settings = {}) => {
               res.send({ app: app.id, updated: result.updated, version: result.version });
               const msg = result.updated
                 ? `API: ...updated app '${ app.id }' to version ${ result.version }.`
-                : `API: ...did not update app '${ app.id }', latest version ${ result.version } already running.`
+                : `API: ...did not update app '${ app.id }', latest version ${ result.version } already running.`;
               log.info(msg);
           })
           .catch(err => res.status(500).send({ message: err.message }));

--- a/src/api-status.js
+++ b/src/api-status.js
@@ -14,16 +14,15 @@ const HOST_NAME = process.env.HOSTNAME || "unknown";
  * Provides status details about the gateway and apps.
  *
  * @param {Object} settings:
- *                  - apps:       Collection of apps to start.
+ *                  - mainApi:    The main API.
  *                  - manifest:   A manifest object.
- *
  */
 export default (settings = {}) => {
-  const { apps, manifest } = settings;
+  const { mainApi, manifest } = settings;
   const processNameToAppId = (name) => name.split(":")[0];
   const getApp = (id) => {
     id = processNameToAppId(id);
-    return R.find(app => app.id === id, apps);
+    return R.find(app => app.id === id, mainApi.apps);
   };
 
 

--- a/src/api-webhook.js
+++ b/src/api-webhook.js
@@ -6,12 +6,11 @@ import log from "./log";
  * Handles web-hook callbacks from Github.
  *
  * @param {Object} settings:
- *                  - apps:       Collection of apps to start.
- *                  - manifest:   A manifest object.
+ *                  - mainApi:    The main API.
  *
  */
 export default (settings = {}) => {
-  const { apps } = settings;
+  const { mainApi } = settings;
   return {
     post(req, res) {
       // Extract data.
@@ -21,7 +20,7 @@ export default (settings = {}) => {
 
       // Match apps that reside within the repo that Github posted.
       const isRepoMatch = (app) => app.repo.name === repo && app.branch === branch;
-      const matchingApps = R.filter(isRepoMatch, apps);
+      const matchingApps = R.filter(isRepoMatch, mainApi.apps);
 
       // Update any matching apps.
       if (matchingApps.length > 0) {

--- a/src/api-webhook.js
+++ b/src/api-webhook.js
@@ -11,14 +11,13 @@ import log from "./log";
  *
  */
 export default (settings = {}) => {
-  const { apps, manifest } = settings;
+  const { apps } = settings;
   return {
     post(req, res) {
       // Extract data.
       const data = req.body;
       const branch = (data.ref && R.last(data.ref.split("/"))) || data.repository.default_branch;
       const repo = data.repository.full_name;
-      const modified = (data.head_commit && data.head_commit.modified) || [];
 
       // Match apps that reside within the repo that Github posted.
       const isRepoMatch = (app) => app.repo.name === repo && app.branch === branch;

--- a/src/api.js
+++ b/src/api.js
@@ -15,7 +15,6 @@ pm2.connect().then(() => isConnected = true);
  * The API to the gateway service.
  *
  * @param {Object} settings:
- *                  - apps:         Collection of apps to start.
  *                  - middleware:   The express middleware.
  *                  - manifest:     A manifest object.
  *                  - apiRoute:     The base URL to the API.
@@ -23,12 +22,12 @@ pm2.connect().then(() => isConnected = true);
  *
  */
 export default (settings = {}) => {
-  const { apiRoute, apps, middleware, manifest, mainApi } = settings;
+  const { apiRoute, middleware, manifest, mainApi } = settings;
   const baseRoute = Route.parse(apiRoute);
 
-  const status = apiStatus({ apps, manifest });
-  const webhook = apiWebhook({ apps, manifest });
-  const actions = apiActions({ apps, mainApi });
+  const status = apiStatus({ mainApi, manifest });
+  const webhook = apiWebhook({ mainApi });
+  const actions = apiActions({ mainApi });
 
   const tokens = R.pipe(
       R.reject(R.isNil),

--- a/src/app-update.js
+++ b/src/app-update.js
@@ -31,7 +31,7 @@ export default (id, localFolder, getVersion, startDownload, start, options = {})
       } catch (err) { return reject(err); }
 
       // Prepare return value.
-      const result = { id, updated: false, installed: false, version: version.remote };
+      const result = { id, updated: false, installed: false, version: version.remote, exists: true };
       if (!result.version) {
         result.exists = false;  // Must exist in remote repo to be considered to exist.
                                 //    It may not exist if the manifest contains an error to
@@ -56,7 +56,7 @@ export default (id, localFolder, getVersion, startDownload, start, options = {})
         restart = true;
       }
 
-      // NPM install if required.
+      // Run NPM install if required.
       if (result.exists && !nodeModulesExist || version.isDependenciesChanged) {
         log.info(`Running [npm install] for '${ id }'...`);
         yield appInstall(localFolder);

--- a/src/app-version.js
+++ b/src/app-version.js
@@ -42,11 +42,11 @@ export default (id, gettinglocalPackage, gettingRemotePackage) => {
           localPackage = yield gettinglocalPackage;
           remotePackage = yield gettingRemotePackage;
         } catch (err) {
-          if (err.error && err.error.status === 404) {
+          if (err.error && err.error.status === 404) { // eslint-disable-line no-empty
             // Ignore - The repo/branch does not exist.
             //          This is a non-failing error.
           } else {
-            return reject(err)
+            return reject(err);
           }
         }
 

--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,7 @@ import { getLocalPackage, getRemotePackage } from "./app-package";
  *                             restricted resources.
  *                                 see: https://github.com/settings/tokens
  *            - route:         Route details for directing requests to the app.
+ *                             {String} or {Array} of strings.
  *            - targetFolder:  The root location where apps are downloaded to.
  *            - repo:          The Github 'username/repo'.
  *                             Optionally you can specify a sub-path within the repos
@@ -40,11 +41,12 @@ export default (settings = {}) => {
   if (isEmpty(id)) { throw new Error(`'id' for the app is required`); }
   if (isEmpty(repo)) { throw new Error(`'repo' name required, eg. 'username/my-repo'`); }
   if (isEmpty(userAgent)) { throw new Error(`The github API user-agent must be specified.  See: https://developer.github.com/v3/#user-agent-required`); }
-  if (isEmpty(route)) { throw new Error(`A 'route' must be specified for the '${ id }' app.`); }
-  route = Route.parse(route);
+  if (isEmpty(route)) { throw new Error(`One or more 'route' values must be specified for the '${ id }' app.`); }
+
   branch = branch || "master";
   targetFolder = targetFolder || DEFAULT_TARGET_FOLDER;
   port = port || DEFAULT_APP_PORT;
+  const routes = Route.parseAll(route);
   const WORKING_DIRECTORY = process.cwd();
 
   // Extract the repo and sub-path.
@@ -65,7 +67,7 @@ export default (settings = {}) => {
   const app = {
     id,
     repo,
-    route,
+    routes,
     port,
     branch,
     localFolder,
@@ -173,7 +175,7 @@ export default (settings = {}) => {
             const result = {
               id,
               port: this.port,
-              route: this.route,
+              routes: this.routes,
               version: status.version
             };
 

--- a/src/gateway-router.js
+++ b/src/gateway-router.js
@@ -19,18 +19,24 @@ proxy.on("error", (err) => {
 
 
 
-
-export default (apps, middleware) => {
-  apps = sortAppsByRoute(apps);
-  const findMatchingApp = (domain, path) => {
-        return R.find(app => app.route.match(domain, path), apps);
-      };
+/**
+ * Starts the gateway.
+ *
+ * @param options:
+ *            - middleware:     The express middleware.
+ *            - mainApi:        The main API.
+ *
+*/
+export default (settings = {}) => {
+  const { middleware, mainApi } = settings;
+  const apps = sortAppsByRoute(mainApi.apps);
 
   middleware.get("*", (req, res) => {
       const host = req.get("host");
       const domain = (host && host.split(":")[0]) || "*";
       const path = req.url;
-      const app = findMatchingApp(domain, path);
+      const app = mainApi.findAppFromRoute(domain, path);
+
       if (app) {
         // An app matches the current route.
         // Proxy the request to it.

--- a/src/gateway-router.js
+++ b/src/gateway-router.js
@@ -1,6 +1,5 @@
 import R from "ramda";
 import httpProxy from "http-proxy"; // See: https://github.com/nodejitsu/node-http-proxy
-import { sortAppsByRoute } from "./util";
 import log from "./log";
 
 
@@ -29,7 +28,6 @@ proxy.on("error", (err) => {
 */
 export default (settings = {}) => {
   const { middleware, mainApi } = settings;
-  const apps = sortAppsByRoute(mainApi.apps);
 
   middleware.get("*", (req, res) => {
       const host = req.get("host");

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -12,7 +12,6 @@ let server;
 /**
  * Starts the gateway.
  * @param options:
- *            - apps:           The array of applications.
  *            - manifest:       The manifest to add apps from.
  *            - port:           The port to use.
  *            - publishEvent:   Function that publishes an event across all containers (via RabbitMQ).
@@ -22,7 +21,7 @@ let server;
 const start = (settings = {}) => {
     return new Promise((resolve, reject) => {
       Promise.coroutine(function*() {
-        const { apps, manifest, mainApi } = settings;
+        const { manifest, mainApi } = settings;
         const port = settings.port || DEFAULT_GATEWAY_PORT;
         const middleware = express().use(bodyParser.json());
 
@@ -44,7 +43,7 @@ const start = (settings = {}) => {
         }
 
         // Routes.
-        if (apiRoute) { api({ apiRoute, apps, middleware, manifest, mainApi }); }
+        if (apiRoute) { api({ apiRoute, middleware, manifest, mainApi }); }
         gatewayRouter({ middleware, mainApi });
 
         // Listen on the desired port.

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -22,7 +22,7 @@ let server;
 const start = (settings = {}) => {
     return new Promise((resolve, reject) => {
       Promise.coroutine(function*() {
-        const { apps, manifest, publishEvent, mainApi } = settings;
+        const { apps, manifest, mainApi } = settings;
         const port = settings.port || DEFAULT_GATEWAY_PORT;
         const middleware = express().use(bodyParser.json());
 

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -45,7 +45,7 @@ const start = (settings = {}) => {
 
         // Routes.
         if (apiRoute) { api({ apiRoute, apps, middleware, manifest, mainApi }); }
-        gatewayRouter(apps, middleware);
+        gatewayRouter({ middleware, mainApi });
 
         // Listen on the desired port.
         server = middleware.listen(port, () => {

--- a/src/main-start.js
+++ b/src/main-start.js
@@ -57,7 +57,7 @@ export default (settings = {}) => {
         log.info(`Gateway running on port:${ port }`);
         log.info("");
         items.forEach(item => {
-            if (item) {
+            if (item && item.exists) {
               const version = item.version ? ` (v${ item.version })` : "";
               log.info(` - '${ item.id }'${ version } routing '${ item.route }' => port:${ item.port }`);
             }

--- a/src/main-start.js
+++ b/src/main-start.js
@@ -57,8 +57,10 @@ export default (settings = {}) => {
         log.info(`Gateway running on port:${ port }`);
         log.info("");
         items.forEach(item => {
-            const version = item.version ? ` (v${ item.version })` : "";
-            log.info(` - '${ item.id }'${ version } routing '${ item.route }' => port:${ item.port }`);
+            if (item) {
+              const version = item.version ? ` (v${ item.version })` : "";
+              log.info(` - '${ item.id }'${ version } routing '${ item.route }' => port:${ item.port }`);
+            }
         });
         log.info("");
 

--- a/src/main-start.js
+++ b/src/main-start.js
@@ -58,7 +58,7 @@ export default (settings = {}) => {
         items.forEach(item => {
             if (item && item.exists) {
               const version = item.version ? ` (v${ item.version })` : "";
-              log.info(` - '${ item.id }'${ version } routing '${ item.route }' => port:${ item.port }`);
+              log.info(` - '${ item.id }'${ version } routing '${ item.routes.toString() }' => port:${ item.port }`);
             }
         });
         log.info("");

--- a/src/main-start.js
+++ b/src/main-start.js
@@ -3,7 +3,6 @@ import gateway from "./gateway";
 import log from "./log";
 import pm2 from "./pm2";
 import { promises, sortAppsByRoute } from "./util";
-import { DEFAULT_GATEWAY_PORT } from "./const";
 
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ if (shell.exec("pm2 -v", { silent: true }).code !== 0) {
 export default (settings = {}) => {
   const userAgent = settings.userAgent || "app-syncer";
   const token = settings.token;
-  let publishEvent;
+  let publishEvent, currentGatewayPort;
 
   const api = {
     uid: uuid.v4().toString(),
@@ -169,12 +169,12 @@ export default (settings = {}) => {
      * @return {Promise}
      */
     start(options = {}) {
-      api.gatewayPort = options.port === undefined ? DEFAULT_GATEWAY_PORT : options.port;
+      currentGatewayPort = options.port === undefined ? DEFAULT_GATEWAY_PORT : options.port;
       return start({
         apps: this.apps,
         update: (args) => this.update(args),
         manifest: this.manifest,
-        port: api.gatewayPort,
+        port: currentGatewayPort,
         publishEvent,
         mainApi: api
       });
@@ -190,8 +190,8 @@ export default (settings = {}) => {
           try {
 
               yield api.stop();
-              yield api.start({ port: api.gatewayPort });
-              resolve({ port: api.gatewayPort });
+              yield api.start({ port: currentGatewayPort });
+              resolve({ port: currentGatewayPort });
 
           } catch (err) { reject(err); }
         }).call(this);

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -18,18 +18,22 @@ export const getManifest = (repo, repoPath, branch) => {
         return reject(new Error("A path to a YAML file must be specified (.yml)"));
       }
 
-      // Pull file from the repo.
-      const download = yield repo.get(repoPath, { branch }).catch(err => reject(err));
-      const files = download && download.files;
+      try {
+        // Pull file from the repo.
+        const download = yield repo.get(repoPath, { branch });
+        const files = download && download.files;
 
-      // Parse and return the manifest.
-      if (files && files.length > 0) {
-        const manifest = files[0].toString();
-        try {
-          resolve(yaml.safeLoad(manifest));
-        } catch (e) {
-          reject(new Error(`Failed while parsing YAML: ${ e.message }`));
+        // Parse and return the manifest.
+        if (files && files.length > 0) {
+          const manifest = files[0].toString();
+          try {
+            resolve(yaml.safeLoad(manifest));
+          } catch (e) {
+            reject(new Error(`Failed while parsing YAML: ${ e.message }`));
+          }
         }
+      } catch (err) {
+        return reject(err);
       }
     })();
   });
@@ -82,7 +86,6 @@ export default (settings = {}) => {
      * @return {Promise}
      */
     get() {
-
       return new Promise((resolve, reject) => {
         Promise.coroutine(function*() {
             try {
@@ -146,6 +149,8 @@ export default (settings = {}) => {
               if (!R.is(String, manifestApp.route)) { throw new Error(`The app '${ id } does not have a route, eg: www.domain.com/path'`); }
               manifestApp.branch = manifestApp.branch || "master";
               const app = getApp(id);
+              // console.log("id", id);
+              // console.log("app.id", app.id);
               if (app) {
                 if (isAppChanged(manifestApp, app)) {
                   // The app has changed. Replace it with the new definition.

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -145,12 +145,13 @@ export default (settings = {}) => {
             // Add or update each app.
             for (let id of manifestKeys) {
               const manifestApp = manifest.apps[id];
-              if (!R.is(String, manifestApp.repo)) { throw new Error(`The app '${ id } does not have a repo, eg: user/repo/path'`); }
-              if (!R.is(String, manifestApp.route)) { throw new Error(`The app '${ id } does not have a route, eg: www.domain.com/path'`); }
+              if (!R.is(String, manifestApp.repo)) { throw new Error(`The app '${ id }' does not have a repo, eg: user/repo/path'`); }
+              if (!(R.is(String, manifestApp.route) || R.is(Array, manifestApp.route))) {
+                throw new Error(`The app '${ id }' does not have a route, eg: www.domain.com/path'`);
+              }
               manifestApp.branch = manifestApp.branch || "master";
+
               const app = getApp(id);
-              // console.log("id", id);
-              // console.log("app.id", app.id);
               if (app) {
                 if (isAppChanged(manifestApp, app)) {
                   // The app has changed. Replace it with the new definition.

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -69,7 +69,7 @@ const toRepoObject = (repoPath) => {
  */
 export default (settings = {}) => {
   // Setup initial conditions.
-  const { userAgent, token, repoPath, mainApi, publishEvent } = settings;
+  const { userAgent, token, repoPath, mainApi } = settings;
 
   // Create the repo proxy.
   const repoObject = toRepoObject(repoPath);
@@ -89,7 +89,7 @@ export default (settings = {}) => {
       return new Promise((resolve, reject) => {
         Promise.coroutine(function*() {
             try {
-              this.current = yield getManifest(repo, this.repo.path, this.repo.branch)
+              this.current = yield getManifest(repo, this.repo.path, this.repo.branch);
               resolve(this.current);
             } catch (err) {
               reject(err);

--- a/src/pm2.js
+++ b/src/pm2.js
@@ -66,7 +66,13 @@ const connect = () => {
 const apps = (filter) => {
     return new Promise((resolve) => {
       Promise.coroutine(function*() {
-        let list = (yield listP()) || [];
+        let list;
+        try {
+          list = (yield listP()) || [];
+        } catch (err) {
+          list = [];
+        }
+
         const isAppProcess = (item) => {
               // Apps can be identified by having a port in the 5000 range,
               // eg: <name>:5001

--- a/src/pub-sub.js
+++ b/src/pub-sub.js
@@ -33,12 +33,12 @@ export default (settings = {}) => {
       };
 
   const catchSubscribeError = (title, err) => {
-        if (err.code !== "ECONNREFUSED") { log.error(`${ title } Event -`, err) };
+        if (err.code !== "ECONNREFUSED") { log.error(`${ title } Event -`, err); }
       };
 
   // Log that connection is ready.
   pubsub.ready()
-    .then(result => {
+    .then(() => {
       log.info(`Connected to RabbitMQ on '${ url }'\n`);
 
       // Listen for events from the other containers.

--- a/src/route.js
+++ b/src/route.js
@@ -39,6 +39,7 @@ const parse = (route) => {
       path = formatMatchValue(path);
       if (path) { path = path.replace(/^\//, ""); }
       const isWildcardDomain = this.domain === "*";
+      const isWildcardPath = this.path === "*";
 
       if (!isWildcardDomain) {
         if (domain !== this.domain) { return false; }
@@ -46,7 +47,11 @@ const parse = (route) => {
 
       if (this.path) {
         if (!path) { return false; }
-        if (path && !(path + "/").startsWith(this.path)) { return false; }
+        if (!isWildcardPath && path && !(path + "/").startsWith(this.path)) { return false; }
+      }
+
+      if (!this.path && path) {
+        return false;
       }
 
       // Finish up.
@@ -65,5 +70,17 @@ const parse = (route) => {
 
 
 
+/**
+ * Parses all routes within the given value(s).
+ * @param {String|Array} route: The Route or Routes to parse.
+ * @return {Array}.
+ */
+const parseAll = (route) => {
+  if (!R.is(Array, route)) { route = [route]; }
+  return R.map(parse, route);
+};
 
-export default { parse };
+
+
+
+export default { parse, parseAll };

--- a/src/route.js
+++ b/src/route.js
@@ -19,9 +19,10 @@ const parse = (route) => {
 
   // URL path.
   let urlPath = R.takeLast(parts.length - 1, parts).join("/").trim();
-  urlPath = isEmpty(urlPath) ? undefined : urlPath;
-  if (urlPath) {
-    urlPath = urlPath.endsWith("/") ? urlPath : urlPath + "/";
+  urlPath = urlPath.replace(/\/$/, "");
+  urlPath = isEmpty(urlPath) ? "*" : urlPath;
+  if (urlPath !== "*") {
+    urlPath += "/";
   }
 
   return {
@@ -45,13 +46,9 @@ const parse = (route) => {
         if (domain !== this.domain) { return false; }
       }
 
-      if (this.path) {
+      if (!isWildcardPath) {
         if (!path) { return false; }
-        if (!isWildcardPath && path && !(path + "/").startsWith(this.path)) { return false; }
-      }
-
-      if (!this.path && path) {
-        return false;
+        if (path && !(path + "/").startsWith(this.path)) { return false; }
       }
 
       // Finish up.

--- a/src/util.js
+++ b/src/util.js
@@ -135,7 +135,6 @@ export const loadJson = (path) => {
  * @return {Array}.
  */
 export const sortAppsByRoute = (apps) => {
-
     let items = apps.map(app => ({ id: app.id, app, routes: app.routes }));
 
     const wildcard = (item) => R.any(r => r.domain === "*", item.routes);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -25,4 +25,35 @@ describe("app", function() {
   it("has a default target folder", () => {
     expect(app(DEFAULT_PARAMS).localFolder).to.equal(fsPath.resolve("./.build/my-app"));
   });
+
+
+  describe("routes", function() {
+    it("stores a single route as an array", () => {
+      expect(app(DEFAULT_PARAMS).routes.length).to.equal(1);
+    });
+
+    it("stores several routes", () => {
+      const SETTINGS = R.clone(DEFAULT_PARAMS);
+      SETTINGS.route = ["*/foo", "www.domain.com"]
+
+      const routes = app(SETTINGS).routes;
+      expect(routes.length).to.equal(2);
+      expect(routes[0].domain).to.equal("*");
+      expect(routes[1].domain).to.equal("www.domain.com");
+    });
+
+    it("throws if a route was not specified", () => {
+      const createWithRoute = (route) => {
+            const SETTINGS = R.clone(DEFAULT_PARAMS);
+            SETTINGS.route = route;
+            return app(SETTINGS);
+          };
+      expect(() => createWithRoute("")).to.throw();
+      expect(() => createWithRoute()).to.throw();
+      expect(() => createWithRoute(null)).to.throw();
+      expect(() => createWithRoute([])).to.throw();
+      expect(() => createWithRoute([""])).to.throw();
+      expect(() => createWithRoute([null, undefined, ""])).to.throw();
+    });
+  });
 });

--- a/test/integration/app.integration-test.js
+++ b/test/integration/app.integration-test.js
@@ -56,6 +56,32 @@ describe("app (integration)", function() {
             expect(version.local).to.equal(version.remote);
         });
     });
+
+    it("does not have a remote version (repo does not exist)", () => {
+      const settings = R.clone(APP_SETTINGS);
+      settings.repo = "username/does-not-exist";
+      settings.branch = "master";
+      // settings.branch = "does-not-exist";
+      const app = new App(settings);
+      return app.version()
+        .then(version => {
+            expect(version.remote).to.equal(null);
+            expect(version.isUpdateRequired).to.equal(undefined);
+            expect(version.isDependenciesChanged).to.equal(undefined);
+        });
+    });
+
+    it("does not have a remote version (branch does not exist)", () => {
+      const settings = R.clone(APP_SETTINGS);
+      settings.branch = "does-not-exist";
+      const app = new App(settings);
+      return app.version()
+        .then(version => {
+            expect(version.remote).to.equal(null);
+            expect(version.isUpdateRequired).to.equal(undefined);
+            expect(version.isDependenciesChanged).to.equal(undefined);
+        });
+    });
   });
 
 

--- a/test/integration/manifest.intergration-test.js
+++ b/test/integration/manifest.intergration-test.js
@@ -1,4 +1,5 @@
 "use strict";
+import R from "ramda";
 import { expect } from "chai";
 import fsPath from "path";
 import fs from "fs-extra";
@@ -24,34 +25,38 @@ describe("manifest (integration)", function() {
     it("retrieves a `manifest.yml`", () => {
       return getManifest(repo, `/example/manifest.yml`, BRANCH)
         .then(result => {
-          expect(result.apps).to.be.an.instanceof(Object);
+            expect(result.apps).to.be.an.instanceof(Object);
+            expect(result.apps.foo).to.be.an.instanceof(Object);
+            expect(result.apps.bar).to.be.an.instanceof(Object);
+            expect(result.apps.foo.route).to.be.a('string');
+            expect(result.apps.bar.route).to.be.an.instanceof(Array);
         });
     });
 
     it("fails if a YAML file was not specified", (done) => {
       getManifest(repo, "/example")
         .catch(err => {
-          expect(err.message).to.equal("A path to a YAML file must be specified (.yml)");
-          done()
+            expect(err.message).to.equal("A path to a YAML file must be specified (.yml)");
+            done();
         });
     });
 
     it("fails to retrieve a manifest (404)", (done) => {
       getManifest(repo, "/does/not/exist.yml")
         .catch(err => {
-          expect(err.status).to.equal(404);
-          done()
+            expect(err.status).to.equal(404);
+            done();
         });
     });
 
     it("fails to parse YAML", (done) => {
       getManifest(repo, `/example/manifest-corrupt.yml`, BRANCH)
         .then(result => {
-          console.log("result", result);
+            console.log("result", result);
         })
         .catch(err => {
-          expect(err.message.startsWith("Failed while parsing YAML")).to.equal(true);
-          done()
+            expect(err.message.startsWith("Failed while parsing YAML")).to.equal(true);
+            done();
         });
     });
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -50,7 +50,7 @@ describe("Main API (module)", () => {
       expect(app.routes[0].domain).to.equal("*");
       expect(app.routes[0].path).to.equal("foo/");
       expect(app.routes[1].domain).to.equal("domain.com");
-      expect(app.routes[1].path).to.equal(undefined);
+      expect(app.routes[1].path).to.equal("*");
     });
 
     it("adds an app with a path to a sub-folder within the repo", () => {
@@ -101,8 +101,8 @@ describe("Main API (module)", () => {
     it("auto-assigns port numbers", () => {
       api.add("my-app-1", "user/my-repo", "*/foo-1");
       api.add("my-app-2", "user/my-repo", "*/foo-2");
-      expect(api.apps[0].port).to.equal(5000);
-      expect(api.apps[1].port).to.equal(5001);
+      expect(api.apps[1].port).to.equal(5000);
+      expect(api.apps[0].port).to.equal(5001);
     });
   });
 
@@ -117,7 +117,7 @@ describe("Main API (module)", () => {
   });
 
 
-  describe(".findAppFromRoute()", function() {
+  describe("findAppFromRoute", function() {
     it("does not match the route value", () => {
       api.add("my-app-1", "user/my-repo", "*/foo-1");
       api.add("my-app-2", "user/my-repo", ["*/foo-2", "*/foo-3"]);
@@ -129,15 +129,15 @@ describe("Main API (module)", () => {
       api.add("my-app-0", "user/my-repo", "*");
       api.add("my-app-1", "user/my-repo", "*/foo-1");
       api.add("my-app-2", "user/my-repo", "*/foo-2");
-      expect(api.findAppFromRoute("*")).to.equal(api.apps[0]);
-      expect(api.findAppFromRoute("*", "foo-1")).to.equal(api.apps[1]);
-      expect(api.findAppFromRoute("*", "foo-2")).to.equal(api.apps[2]);
+      expect(api.findAppFromRoute("*").id).to.equal("my-app-0");
+      expect(api.findAppFromRoute("*", "foo-1").id).to.equal("my-app-1");
+      expect(api.findAppFromRoute("*", "foo-2").id).to.equal("my-app-2");
     });
 
     it("matches from multiple routes per app.", () => {
       api.add("my-app-1", "user/my-repo", "*/foo-1");
       api.add("my-app-2", "user/my-repo", ["*/foo-2", "*/bar"]);
-      expect(api.findAppFromRoute("*", "bar")).to.equal(api.apps[1]);
+      expect(api.findAppFromRoute("*", "bar").id).to.equal("my-app-2");
     });
   });
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -38,8 +38,19 @@ describe("Main API (module)", () => {
       expect(app.id).to.equal("my-app");
       expect(app.repo.name).to.equal("philcockfield/app-sync");
       expect(app.localFolder).to.equal(fsPath.resolve("./.build/my-app"));
-      expect(app.route.domain).to.equal("*");
-      expect(app.route.path).to.equal("foo/");
+      expect(app.routes.length).to.equal(1);
+      expect(app.routes[0].domain).to.equal("*");
+      expect(app.routes[0].path).to.equal("foo/");
+    });
+
+    it("adds an app with several incoming routes", () => {
+      api.add("my-app", "philcockfield/app-sync", ["*/foo", "domain.com"]);
+      const app = api.apps[0];
+      expect(app.routes.length).to.equal(2);
+      expect(app.routes[0].domain).to.equal("*");
+      expect(app.routes[0].path).to.equal("foo/");
+      expect(app.routes[1].domain).to.equal("domain.com");
+      expect(app.routes[1].path).to.equal(undefined);
     });
 
     it("adds an app with a path to a sub-folder within the repo", () => {
@@ -77,12 +88,15 @@ describe("Main API (module)", () => {
 
     it("throws if a route is repeated", () => {
       api.add("my-app-1", "user/my-repo-1", "*/foo");
-      let fn = () => {
-        api.add("my-app-2", "user/my-repo-2", "*/foo");
-      };
+      let fn = () => api.add("my-app-2", "user/my-repo-2", ["domain.com", "*/foo"]);
       expect(fn).to.throw();
     });
 
+    it("throws if a route is repeated (within an array)", () => {
+      api.add("my-app-1", "user/my-repo-1", ["domain.com", "*/foo"]);
+      let fn = () => api.add("my-app-2", "user/my-repo-2", ["google.com", "*/foo"]);
+      expect(fn).to.throw();
+    });
 
     it("auto-assigns port numbers", () => {
       api.add("my-app-1", "user/my-repo", "*/foo-1");
@@ -99,6 +113,31 @@ describe("Main API (module)", () => {
       .then(result => {
           expect(api.apps.length).to.equal(0);
       });
+    });
+  });
+
+
+  describe(".findAppFromRoute()", function() {
+    it("does not match the route value", () => {
+      api.add("my-app-1", "user/my-repo", "*/foo-1");
+      api.add("my-app-2", "user/my-repo", ["*/foo-2", "*/foo-3"]);
+      expect(api.findAppFromRoute("*", "bar")).to.equal(undefined);
+      expect(api.findAppFromRoute("*")).to.equal(undefined);
+    });
+
+    it("matches with a single route per app.", () => {
+      api.add("my-app-0", "user/my-repo", "*");
+      api.add("my-app-1", "user/my-repo", "*/foo-1");
+      api.add("my-app-2", "user/my-repo", "*/foo-2");
+      expect(api.findAppFromRoute("*")).to.equal(api.apps[0]);
+      expect(api.findAppFromRoute("*", "foo-1")).to.equal(api.apps[1]);
+      expect(api.findAppFromRoute("*", "foo-2")).to.equal(api.apps[2]);
+    });
+
+    it("matches from multiple routes per app.", () => {
+      api.add("my-app-1", "user/my-repo", "*/foo-1");
+      api.add("my-app-2", "user/my-repo", ["*/foo-2", "*/bar"]);
+      expect(api.findAppFromRoute("*", "bar")).to.equal(api.apps[1]);
     });
   });
 });

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -27,11 +27,12 @@ describe("route", function() {
 
 
   describe("match", function() {
-    it("matches on specific domain (no path)", () => {
+    it.only("matches on specific domain (no path)", () => {
       expect(route.parse("www.foo.com").match("www.foo.com")).to.equal(true);
       expect(route.parse("www.foo.com").match("www.foo.com", "")).to.equal(true);
-      expect(route.parse("www.foo.com").match("www.foo.com", "bar")).to.equal(true);
-      expect(route.parse("www.foo.com").match("www.foo.com", "/bar")).to.equal(true);
+
+      // expect(route.parse("www.foo.com/*").match("www.foo.com", "bar")).to.equal(true);
+      // expect(route.parse("www.foo.com").match("www.foo.com", "/bar")).to.equal(true);
     });
 
     it("matches on specific domain (with path)", () => {
@@ -42,7 +43,8 @@ describe("route", function() {
 
     it("does not match on specific domain (no path)", () => {
       expect(route.parse("www.foo.com").match("www.bar.org")).to.equal(false);
-      expect(route.parse("www.foo.com").match("www.bar.org/foo")).to.equal(false);
+      expect(route.parse("www.foo.com").match("www.bar.org", "foo")).to.equal(false);
+      expect(route.parse("www.foo.com").match("www.foo.com", "bar")).to.equal(false);
     });
 
     it("does not match on specific domain (with path)", () => {
@@ -64,8 +66,8 @@ describe("route", function() {
 
     it("does not match on wildcard domain (*) with path", () => {
       expect(route.parse("*/foo").match("bar.com")).to.equal(false);
-      expect(route.parse("*/foo").match("bar.com/")).to.equal(false);
-      expect(route.parse("*/foo").match("bar.com/bar")).to.equal(false);
+      expect(route.parse("*/foo").match("bar.com", "bar")).to.equal(false);
+      expect(route.parse("*").match("bar.com", "bar")).to.equal(false);
     });
   });
 });

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -17,22 +17,29 @@ describe("route", function() {
     expect(route.parse("*/").domain).to.equal("*");
     expect(route.parse(" * ").domain).to.equal("*");
     expect(route.parse(" *  /").domain).to.equal("*");
+    expect(route.parse(" *  /path").domain).to.equal("*");
   });
 
 
-  it("has no path", () => {
-    expect(route.parse("*").path).to.equal(undefined);
-    expect(route.parse("*/ ").path).to.equal(undefined);
+  it("has a wildcard path (*)", () => {
+    expect(route.parse("*").path).to.equal("*");
+    expect(route.parse("*/").path).to.equal("*");
+    expect(route.parse("*/  ").path).to.equal("*");
+    expect(route.parse("*/*").path).to.equal("*");
+    expect(route.parse("*/*/").path).to.equal("*");
+    expect(route.parse("*/  *  ").path).to.equal("*");
+    expect(route.parse("domain.com/*").path).to.equal("*");
+    expect(route.parse("domain.com").path).to.equal("*");
   });
 
 
   describe("match", function() {
-    it.only("matches on specific domain (no path)", () => {
+    it("matches on specific domain (no path)", () => {
       expect(route.parse("www.foo.com").match("www.foo.com")).to.equal(true);
       expect(route.parse("www.foo.com").match("www.foo.com", "")).to.equal(true);
-
-      // expect(route.parse("www.foo.com/*").match("www.foo.com", "bar")).to.equal(true);
-      // expect(route.parse("www.foo.com").match("www.foo.com", "/bar")).to.equal(true);
+      expect(route.parse("www.foo.com/*").match("www.foo.com", "bar")).to.equal(true);
+      expect(route.parse("www.foo.com/*").match("www.foo.com", "/bar")).to.equal(true);
+      expect(route.parse("www.foo.com").match("www.foo.com", "/bar")).to.equal(true);
     });
 
     it("matches on specific domain (with path)", () => {
@@ -44,7 +51,6 @@ describe("route", function() {
     it("does not match on specific domain (no path)", () => {
       expect(route.parse("www.foo.com").match("www.bar.org")).to.equal(false);
       expect(route.parse("www.foo.com").match("www.bar.org", "foo")).to.equal(false);
-      expect(route.parse("www.foo.com").match("www.foo.com", "bar")).to.equal(false);
     });
 
     it("does not match on specific domain (with path)", () => {
@@ -62,12 +68,12 @@ describe("route", function() {
     it("matches on wildcard domain (*) with no path", () => {
       expect(route.parse("*").match("foo.com")).to.equal(true);
       expect(route.parse("*").match("bar.com")).to.equal(true);
+      expect(route.parse("*").match("bar.com", "path")).to.equal(true);
     });
 
     it("does not match on wildcard domain (*) with path", () => {
       expect(route.parse("*/foo").match("bar.com")).to.equal(false);
       expect(route.parse("*/foo").match("bar.com", "bar")).to.equal(false);
-      expect(route.parse("*").match("bar.com", "bar")).to.equal(false);
     });
   });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -2,60 +2,45 @@
 import R from "ramda";
 import { expect } from "chai";
 import * as util from "../src/util";
-
+import Route from "../src/route";
 
 
 describe("util", function() {
-  describe("sortRoutes", function() {
+  describe("sortAppsByRoute", function() {
     it("sorts with wildcards and no wildcards", () => {
       let apps = [
-        { id: 0, route: "*/z" },
-        { id: 1, route: "*" },
-        { id: 2, route: "z.domain.com" },
-        { id: 3, route: "*/b" },
-        { id: 4, route: "apple.domain.com" },
-        { id: 5, route: "*/a" },
+        { id: 0, routes: Route.parseAll("*/z") },
+        { id: 1, routes: Route.parseAll("*") },
+        { id: 2, routes: Route.parseAll("z.domain.com") },
+        { id: 3, routes: Route.parseAll(["*/b", "*/c"]) },
+        { id: 4, routes: Route.parseAll("apple.domain.com") },
+        { id: 5, routes: Route.parseAll("*/a") },
       ];
       apps = util.sortAppsByRoute(apps);
-      apps = util.sortAppsByRoute(apps);
-      expect(apps).to.eql([
-        { id: 4, route: "apple.domain.com" },
-        { id: 2, route: "z.domain.com" },
-        { id: 5, route: "*/a" },
-        { id: 3, route: "*/b" },
-        { id: 0, route: "*/z" },
-        { id: 1, route: "*" }
-      ]);
+      apps = util.sortAppsByRoute(apps); // Ensure idempotent.
+      expect(apps.map(item => item.id)).to.eql([4, 2, 5, 3, 0, 1]);
     });
 
     it("sorts with no wildcards", () => {
       let apps = [
-        { id: 2, route: "z.domain.com" },
-        { id: 4, route: "apple.domain.com" }
+        { id: 2, routes: Route.parseAll("z.domain.com") },
+        { id: 4, routes: Route.parseAll("apple.domain.com") }
       ];
       apps = util.sortAppsByRoute(apps);
-      apps = util.sortAppsByRoute(apps);
-      expect(apps).to.eql([
-        { id: 4, route: "apple.domain.com" },
-        { id: 2, route: "z.domain.com" }
-      ]);
+      apps = util.sortAppsByRoute(apps); // Ensure idempotent.
+      expect(apps.map(item => item.id)).to.eql([4, 2]);
     });
 
     it("sorts with only wildcards", () => {
       let apps = [
-        { id: 0, route: "*/z" },
-        { id: 1, route: "*" },
-        { id: 3, route: "*/b" },
-        { id: 5, route: "*/a" },
+        { id: 0, routes: Route.parseAll("*/z") },
+        { id: 1, routes: Route.parseAll("*") },
+        { id: 3, routes: Route.parseAll("*/b") },
+        { id: 5, routes: Route.parseAll("*/a") },
       ];
       apps = util.sortAppsByRoute(apps);
-      apps = util.sortAppsByRoute(apps);
-      expect(apps).to.eql([
-        { id: 5, route: "*/a" },
-        { id: 3, route: "*/b" },
-        { id: 0, route: "*/z" },
-        { id: 1, route: "*" }
-      ]);
+      apps = util.sortAppsByRoute(apps); // Ensure idempotent.
+      expect(apps.map(item => item.id)).to.eql([5, 3, 0, 1]);
     });
   });
 });


### PR DESCRIPTION
## [1.4.0] - 2015-12-29

#### Added
- API: `/api/apps` listing of all the apps (subset of the root status data-set.  
  Makes for a logically consistent API).

#### Changed
- Manifest: Now optionally supporting an array of routes per app.
- Sorting apps by route upon adding them to the main API.

#### Removed
- Removed auto-restart when `manifest.yml` file changes.
    - Was causing strange errors.
    - Now when the manifest changes force a restart using the REST api: `/api/restart`
